### PR TITLE
feat: `compilerOptions.types` is set for all kinds

### DIFF
--- a/agnostic-module.json
+++ b/agnostic-module.json
@@ -2,6 +2,7 @@
   "extends": "./_private/module",
   "compilerOptions": {
     "lib": ["ESNext"],
-    "module": "CommonJS"
+    "module": "CommonJS",
+    "types": []
   }
 }

--- a/browser-executable.json
+++ b/browser-executable.json
@@ -2,6 +2,7 @@
   "extends": "./_private/executable",
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
-    "module": "ESNext"
+    "module": "ESNext",
+    "types": []
   }
 }

--- a/browser-module.json
+++ b/browser-module.json
@@ -2,6 +2,7 @@
   "extends": "./_private/module",
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
-    "module": "ESNext"
+    "module": "ESNext",
+    "types": []
   }
 }

--- a/nodejs-executable.json
+++ b/nodejs-executable.json
@@ -2,6 +2,9 @@
   "extends": "./_private/executable",
   "compilerOptions": {
     "lib": ["ESNext"],
-    "module": "CommonJS"
+    "module": "CommonJS",
+    "types": [
+      "node"
+    ]
   }
 }

--- a/nodejs-module.json
+++ b/nodejs-module.json
@@ -2,6 +2,9 @@
   "extends": "./_private/module",
   "compilerOptions": {
     "lib": ["ESNext"],
-    "module": "CommonJS"
+    "module": "CommonJS",
+    "types": [
+      "node"
+    ]
   }
 }

--- a/src/agnostic-module.test.ts
+++ b/src/agnostic-module.test.ts
@@ -8,7 +8,8 @@ test(unitTest, 'agnostic-module', {
     ...common,
     ...importable,
     lib: ['ESNext'],
-    module: 'CommonJS'
+    module: 'CommonJS',
+    types: []
   }
 })
 

--- a/src/browser-executable.test.ts
+++ b/src/browser-executable.test.ts
@@ -8,7 +8,8 @@ test(unitTest, 'browser-executable', {
     ...common,
     ...executable,
     lib: ['ESNext', 'DOM'],
-    module: 'ESNext'
+    module: 'ESNext',
+    types: []
   }
 })
 

--- a/src/browser-module.test.ts
+++ b/src/browser-module.test.ts
@@ -8,7 +8,8 @@ test(unitTest, 'browser-module', {
     ...common,
     ...importable,
     lib: ['ESNext', 'DOM'],
-    module: 'ESNext'
+    module: 'ESNext',
+    types: []
   }
 })
 

--- a/src/nodejs-executable.test.ts
+++ b/src/nodejs-executable.test.ts
@@ -9,7 +9,10 @@ test(unitTest, 'nodejs-executable',
       ...common,
       ...executable,
       lib: ['ESNext'],
-      module: 'CommonJS'
+      module: 'CommonJS',
+      types: [
+        'node'
+      ]
     }
   }
 )

--- a/src/nodejs-module.test.ts
+++ b/src/nodejs-module.test.ts
@@ -8,7 +8,10 @@ test(unitTest, 'nodejs-module', {
     ...common,
     ...importable,
     lib: ['ESNext'],
-    module: 'CommonJS'
+    module: 'CommonJS',
+    types: [
+      'node'
+    ]
   }
 })
 

--- a/src/webworker-module.test.ts
+++ b/src/webworker-module.test.ts
@@ -8,7 +8,8 @@ test(unitTest, 'webworker-module', {
     ...common,
     ...importable,
     lib: ['ESNext', 'WebWorker'],
-    module: 'ESNext'
+    module: 'ESNext',
+    types: []
   }
 })
 

--- a/webworker-module.json
+++ b/webworker-module.json
@@ -2,6 +2,7 @@
   "extends": "./_private/module",
   "compilerOptions": {
     "lib": ["ESNext", "WebWorker"],
-    "module": "ESNext"
+    "module": "ESNext",
+    "types": []
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: in order to disable automatic inclusion of @types packages,
`compilerOptions.types` is set for all project kinds. in the case of
`browser-module`, `browser-executable`, `webworker-module` and
`agnostic-module`, it was previously unset and now it is set to `[]`. In order
to include an @types package, `compilerOptions.types` must override the value
set by the project kind. Extending from any of the `nodejs` kinds, the override
should also include `"node"`. For example, to include the
`@types/webpack-dev-server` package, the value of your
`compilerOptions.types` should be `["node", "webpack-dev-server"]`.